### PR TITLE
Add `close()` for `RecordAsyncWriter`

### DIFF
--- a/src/record_writer/async.rs
+++ b/src/record_writer/async.rs
@@ -67,6 +67,12 @@ where
         Ok(())
     }
 
+    /// Closes the inner writer.
+    pub async fn close(&mut self) -> Result<()> {
+        self.writer.close().await?;
+        Ok(())
+    }
+
     /// Convert into a [Sink].
     pub fn into_sink(self) -> impl Sink<T, Error = Error> {
         sink::unfold(self, |mut writer, record| async move {


### PR DESCRIPTION
Similar to `flush()` that flushes the inner writer, we need a `close()` that closes the inner writer. 